### PR TITLE
[공통 - Minseon] 17681

### DIFF
--- a/programmers/17681/Minseon_17681.java
+++ b/programmers/17681/Minseon_17681.java
@@ -1,0 +1,37 @@
+/**
+ * == 17681. 비밀지도 ==
+ * 입력: 지도의 한 변 크기 n, 2개의 정수 배열 arr1, arr2
+ * 출력: 비밀지도를 해독하여 '#'와 공백으로 이루어진 문자열 배열 출력
+ */
+
+class Solution {
+    public String[] solution(int n, int[] arr1, int[] arr2) {
+        String[] map1 = makeMap(n, arr1);
+        String[] map2 = makeMap(n, arr2);
+
+        /* 전체 지도 */
+        String[] answer = new String[n];
+        for (int i = 0; i < n; i++) {
+            String temp = "";
+            for (int j = 0; j < n; j++) {
+                if (map1[i].charAt(j) == '0' && map2[i].charAt(j) == '0') temp += " ";
+                else temp += "#";
+            }
+            answer[i] = temp;
+        }
+
+        return answer;
+    }
+
+    /* 해독: 정수 -> 이진수 변환 */
+    public String[] makeMap(int n, int[] arr) {
+        String[] map = new String[n];
+        for (int i = 0; i < n; i++) {
+            String binary = Long.toBinaryString(arr[i]);
+            String formatString = "%0" + n + "d";
+            binary = String.format(formatString, Long.parseLong(binary));
+            map[i] = binary;
+        }
+        return map;
+    }
+}


### PR DESCRIPTION
### 1️⃣ 어떤 문제인가요?



**[프로그래머스 17681번](https://school.programmers.co.kr/learn/courses/30/lessons/17681)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


- n개의 10진수로 이루어진 비밀지도를 n개의 n자리 이진수로 변환하여 n*n 크기로 맞추고 두 개의 비밀지도를 비교해서 전체 지도를 만드는 문제.
- 테스트케이스 하나로 예로 들면, 지도 1은 [9, 20, 28, 18, 11], 지도 2는 [30, 1, 21, 17, 28]인데 이를 이진수로 변환하면 지도 1은 [01001, 10100, 11100, 10010, 01011], 지도 2는 [11110, 00001, 10101, 10001, 11100]이다. 지도 1과 지도 2를 합친 전체 지도는 [#####, # # #, ### #, #  ##, #####]





<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
처음에는 이진수라고 해서 비트마스킹을 써서 풀까 생각했지만, n이 최대 16으로 그렇게 크지 않아서 단순 구현으로 풀어도 괜찮을 것 같다고 생각했다.
<br>

**어떤 방식으로 풀이할건가요?**
10진수를 이진수로 변환한 지도를 만드는 함수를 만들고, 변환하는 과정에는 Java의 String.format 메소드를 사용하여 이진수의 자릿수를 맞춰주었다. 이진수 변환에는 Integer.toBinaryString 메소드를 사용했다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
앞서 말했듯이 n이 작아서 지도 전체를 탐색해도 최대 16*16=256으로 자원이 많이 소모되지 않을 것이라고 생각했다.




<br>
<br>



### 4️⃣ 아쉬웠던 점
1. String.format을 할 때 "%0Ns"에서 String 타입을 포맷할 때는 앞에 0 flag를 사용할 수 없다는 사실을 늦게 알아서 거기서 시간이 오래 걸렸다.
2. 중간에 테스트 2, 6에서 런타임 초과 에러가 떴었다. 이진수로 변환하는 과정에서 int의 자릿수를 초과해서 long 타입을 한 번 바꿔줬어야 했는데 자릿수를 신경쓰지 못했다.




<br>
<br>



### 5️⃣ 인증

소요시간: 약 35분

<img width="588" alt="10:10 프로그래머스 17681" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/84c11572-bc1c-4e91-bb5f-a490677a4821">




<br/>
