### PR TITLE
[공통 - Minseon] 77486

### DIFF
--- a/programmers/77486/Minseon_77486.java
+++ b/programmers/77486/Minseon_77486.java
@@ -1,0 +1,46 @@
+/**
+ * == 77486. 다단계 칫솔 판매 ==
+ * 입력 : 조직 구성원 enroll, 추천인 referral, 판매원 seller, 판매 수량 amount
+ * 출력 : 모든 조직 구성원들의 이익금 총합 배열
+ */
+
+import java.util.HashMap;
+
+class Solution {
+    public int[] solution(String[] enroll, String[] referral, String[] seller, int[] amount) {
+        HashMap<String, String> parent = new HashMap();     // 추천인과 조직원 연결
+        HashMap<String, Integer> member = new HashMap();    // 조직원과 이익금
+
+        /* 트리 생성 */
+        member.put("-", 0); // center 추가
+        for (int i = 0; i < enroll.length; i++) {
+            parent.put(enroll[i], referral[i]);
+            member.put(enroll[i], 0);
+        }
+
+        /* 이익금 계산 */
+        for (int i = 0; i < seller.length; i++) {
+            int profit = amount[i] * 100;    // 총 이익금
+            String ref = seller[i];          // 부모
+            int fee = profit / 10;           // 수수료
+            member.put(ref, member.get(ref) + profit - fee);
+
+            while (!parent.get(ref).equals("-")) {
+                if (profit == 0) break;
+                profit /= 10;
+                fee = profit / 10;
+
+                ref = parent.get(ref);
+                member.put(ref, member.get(ref) + profit - fee);
+            }
+        }
+
+        /* 이익금 배열 만들기 */
+        int[] answer = new int[enroll.length];
+        for (int i = 0; i < enroll.length; i++) {
+            answer[i] = member.get(enroll[i]);
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 77486번](https://school.programmers.co.kr/learn/courses/30/lessons/77486)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
- 판매원이 번 돈은 판매 수량 * 100이다.
- 판매원이 얻은 수익금은 자신은 90%를 갖고, 자신의 추천인이 10%를 가져가는 방식으로, 이는 center까지 계속 올라가며 적용된다.
- 10%가 1원 미만인 경우에는 본인이 100%를 가진다.
- 원 계산은 소수점은 버린다.




<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
해시
<br>

**어떤 방식으로 풀이할건가요?**
- 조직원과 추천인을 매핑하는 해시맵과 조직원과 이익금을 매핑하는 해시맵을 만든다.
- 이익금의 10%가 1원 미만인 경우는 계산할 때 0으로 들어가므로 따로 처리하지 않아도 된다.
- 이익금의 계산은 (이익금) - (수수료)
- 총 이익금의 계산은 (본래 총 이익금) + (계산한 이익금)
- 위 계산 방식에 따라 seller 배열을 돌면서 한 판매원의 이익금을 center까지 계산한다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
해시맵을 썼기 때문에 최악의 경우에도 O(n)이다. 공간복잡도의 경우 n만큼의 해시맵 2개를 사용하므로 O(2n) = O(n)




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->
- 처음에 해시맵을 2개 쓸 생각을 하지 못하고 Member 클래스를 만들어서 해시맵 1개로 하려고 했는데 너무 복잡해져서 그 부분을 수정했다. 
- 절사가 소수점을 버리는 것이라는 것을 생각하지 못하고 경우의 수를 나누어서 코드를 짜다가 나중에 깨달았다.


<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 약 1시간 30분
<img width="797" alt="11/7 프로그래머스 77486" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/1b734936-059c-483b-880b-e36798996cfe">



<br/>
