### PR TITLE
[공통 - Minseon] 118667

### DIFF
--- a/programmers/118667/Minseon_118667.java
+++ b/programmers/118667/Minseon_118667.java
@@ -1,0 +1,64 @@
+/**
+ * == 118667. 두 큐의 합 같게 만들기 ==
+ * 입력 : 길이가 같은 두 개의 큐
+ * 출력 : 각 큐의 원소 합을 같게 만들기 위해 필요한 작업의 최소 횟수
+ */
+
+import java.util.*;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        Deque<Integer> deque1 = new ArrayDeque<>();
+        Deque<Integer> deque2 = new ArrayDeque<>();
+
+        /* 각 큐의 원소 합 구하기 */
+        long targetSum = 0;     // 목표합
+
+        for (int num : queue1) {
+            targetSum += (long) num;
+            deque1.add(num);
+        }
+        for (int num : queue2) {
+            targetSum += (long) num;
+            deque2.add(num);
+        }
+
+        if (targetSum % 2 == 1) return -1;  // 모든 원소의 합이 홀수이면 같게 할 수 없음
+        targetSum /= 2;
+
+        /* 각 큐의 원소 합 같게 만들기 */
+        int count = 0;  // 작업 횟수
+        long queueSum = getSum(deque1);
+        while (queueSum != targetSum) {
+            if (count > (queue1.length) * 4) return -1; // 최대 횟수 이상 옮기면 같게 할 수 없음
+            if (deque1.size() == 0 || deque2.size() == 0) return -1;    // 한 큐가 빈 큐가 되면 같게 할 수 없음
+            if (queueSum > targetSum) {
+                queueSum -= (long) deque1.peekFirst();
+                count = popAndInsert(deque1, deque2, count, targetSum);
+            }
+            else {
+                queueSum += (long) deque2.peekFirst();
+                count = popAndInsert(deque2, deque1, count, targetSum);
+            }
+
+            if (count == -1) break;
+        }
+
+        return count;
+    }
+
+    private long getSum(Deque<Integer> queue) {
+        long queueSum = 0;
+        for (int num : queue) {
+            queueSum += num;
+        }
+        return queueSum;
+    }
+
+    private int popAndInsert(Deque<Integer> queue1, Deque<Integer> queue2, int count, long targetSum) {
+        int popNum = queue1.removeFirst();  // pop
+        if (popNum > targetSum) return -1;  // 원소가 목표합보다 크면 같게 할 수 없음
+        queue2.add(popNum);                 // insert
+        return ++count;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 118667번](https://school.programmers.co.kr/learn/courses/30/lessons/118667)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
- 하나의 큐에서 첫번째 원소를 pop하고 다른 큐에 마지막 원소로 insert하는 과정을 반복하여 두 큐의 합이 같도록 만드는 문제.
- 원소합을 같게 만들 수 없으면 -1을 return한다.




<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
그리디
<br>

**어떤 방식으로 풀이할건가요?**
- 모든 큐의 원소 합을 구한 다음 2로 나눠 목표합을 구한다. 이때, 목표합이 홀수인 경우 두 큐의 원소합을 같게 만들 수 없다.
- 하나의 큐의 원소 합을 구한 다음, 그 합이 목표합보다 작으면 다른 큐에서 pop하고, 목표합보다 크면 해당 큐에서 pop한다.
- 두 큐의 크기의 합 * 2는 두 큐가 완전히 뒤바뀔 수 있는 횟수이기 때문에 이를 최대 횟수로 설정하고 이 횟수를 넘어가면 원소합을 같게 만들 수 없다고 판단한다.
- pop한 원소가 목표합보다 클 경우 두 큐의 원소합을 같게 만들 수 없다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
최악의 경우 while문이 큐의 길이에 비례한 시간복잡도를 가지므로 O(n^2)




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->




<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 38분
<img width="825" alt="11/9 프로그래머스 118667(1)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/4c3f3b58-271a-4a8f-9129-aaf24932fd25">
<img width="825" alt="11/9 프로그래머스 118667(2)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/546ec357-84f5-4cbb-8da0-04d637665b4a">



<br/>
