### PR TITLE
[공통 - Yebin] 118667

### DIFF
--- a/programmers/118667/Yebin_118667.java
+++ b/programmers/118667/Yebin_118667.java
@@ -1,0 +1,49 @@
+import java.util.Queue;
+import java.util.LinkedList;
+
+class Solution {
+    public int solution(int[] queue1, int[] queue2) {
+        int n = queue1.length * 2;  // 총 원소 개수
+
+        Queue<Integer> q1 = arrayToQ(queue1);
+        Queue<Integer> q2 = arrayToQ(queue2);
+        long sum1 = sumQ(q1);
+        long sum2 = sumQ(q2);
+
+        // 합이 홀수이면 두 큐를 같게 만들 수 없음
+        if (((sum1 + sum2) % 2) != 0) return -1;
+
+        // 각각의 합이 같아질 때까지
+        int count = 0;
+        while (sum1 != sum2) {
+            if (sum1 > sum2) {
+                int ele = q1.poll();
+                q2.add(ele);
+                sum1 -= ele;
+                sum2 += ele;
+            } else {
+                int ele = q2.poll();
+                q1.add(ele);
+                sum2 -= ele;
+                sum1 += ele;
+            }
+            count++;
+            // 모든 원소가 다른 큐에 갔다가 원래 큐로 돌아올 만큼 움직였는데 같아지지 않음
+            if (count > 2 * n) return -1;
+        }
+
+        return count;
+    }
+
+    private Queue<Integer> arrayToQ(int[] queue) {
+        Queue<Integer> q = new LinkedList<>();
+        for (int element : queue) q.add(element);
+        return q;
+    }
+
+    private long sumQ(Queue<Integer> q) {
+        long result = 0;
+        for (Integer element : q) result += element;
+        return result;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?

<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 118667번 두 큐 합 같게 만들기](https://school.programmers.co.kr/learn/courses/30/lessons/118667)**

<br>
<br>

### 2️⃣ 어떻게 문제를 분석했나요?

 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
<img width="434" alt="image" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/5c794a87-0084-4503-a94c-75689c6cdcba">

- 일단 테스트 케이스를 다 써보니까 합이 더 큰 쪽의 큐에서 원소를 빼서 다른 큐에 넣음 
- 그리디 외의 풀이법은 생각이 안나서 위의 방법으로 구현
- 큐를 계속 sum을 하면 시간이 오래 걸릴 것 같아서 변수를 따로 할당해야겠음
- 어떻게 해도 안되는 경우는 다음 두가지 
  1. 모든 원소의 합이 홀수면 둘로 나눠지지 않음
  2. 어떤 조합도 총합의 반이 안되는 경우 

<br>
<br>

### 3️⃣ 어떻게 문제를 풀었나요?

<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
- `그리디`
<br>

**어떤 방식으로 풀이할건가요?**
1. 합이 홀수인 경우를 먼저 -1 반환
2. 합이 더 큰 큐에서 원소를 빼서 다른 큐에 넣음 
3. 2를 반복하다 아무리 원소를 옮겨도 총합의 반이 안되는 경우 반복을 멈추고 -1 반환 
4. 두 큐의 합이 같아지는 횟수를 반환 
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
n을 모든 원소의 개수라고 하면 
- 시간복잡도 : 최악의 경우 모든 원소가 왔다갔다 함 O(n^2) 
- 공간복잡도 : 모든 원소를 큐에 저장하므로 O(n)

<br>
<br>

### 4️⃣ 아쉬웠던 점

 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->

- 아무리 원소를 옮겨도 두 큐의 합이 같아지지 않는 경우를 걸러내는게 어려웠다
  - 처음엔 모든 원소가 서로 상대 큐에 들어가게 바뀌는 경우를 생각해서 count == n인 경우 카운트를 그만하도록 했는데 tc1이 실패함
  - 그래서 그냥 관념적으로... 상대 큐에 갔다가 돌아오는 것까지 생각해서 count == 2n이 된 경우에 그만두도록 했더니 통과함 

<br>
<br>

### 5️⃣ 인증

1시간 
 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->

<img width="394" alt="스크린샷 2023-11-09 오후 11 39 20" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/b8498e22-7f8e-4b87-9bfc-509999508fed">

<br/>
