### PR TITLE
[공통 - Minseon] 17677

### DIFF
--- a/programmers/17677/Minseon_17677.java
+++ b/programmers/17677/Minseon_17677.java
@@ -1,3 +1,9 @@
+/**
+ * == 17677. 뉴스 클러스터링 ==
+ * 입력: 두 문자열 str1, str2
+ * 출력: 두 문자열의 자카드 유사도
+ */
+
 import java.util.*;
 
 class Solution {

--- a/programmers/17677/Minseon_17677.java
+++ b/programmers/17677/Minseon_17677.java
@@ -1,0 +1,44 @@
+import java.util.*;
+
+class Solution {
+    public int solution(String str1, String str2) {
+        /* 다중집합 */
+        List<String> str1_multiset = makeMultiset(str1.toUpperCase(), new ArrayList<>());
+        List<String> str2_multiset = makeMultiset(str2.toUpperCase(), new ArrayList<>());
+
+        if (str1_multiset.isEmpty() && str2_multiset.isEmpty()) return 1 * 65536;   // 둘 다 공집합인 경우 자카드 유사도는 1
+
+        /* 교집합 */
+        List<String> intersection = new ArrayList<>();
+        List<String> temp = new ArrayList<>(str2_multiset);
+        for (String str : str1_multiset) {
+            if (temp.contains(str)) {
+                temp.remove(str);
+                intersection.add(str);
+            }
+        }
+
+        /* 합집합 */
+        List<String> union = new ArrayList<>(str1_multiset);
+        union.addAll(str2_multiset);    // A + B
+
+        for (String str : intersection) {   // A ∪ B = (A + B) - (A ∩ B)
+            union.remove(str);
+        }
+
+        /* 자카드 유사도 */
+        double jaccard = (double) intersection.size() / union.size();
+        return (int) (jaccard * 65536);
+    }
+
+    public List<String> makeMultiset(String str, List<String> multiset) {
+        for (int i = 0; i < str.length()-1; i++) {
+            if ((int) str.charAt(i) < 65 || (int) str.charAt(i) > 90 ||
+                    (int) str.charAt(i+1) < 65 || (int) str.charAt(i+1) > 90) continue;     // 대문자 알파벳이 아니면 원소로 만들지 않음
+            String strElement = str.substring(i, i+2);
+            multiset.add(strElement);
+        }
+
+        return multiset;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 17677번](https://school.programmers.co.kr/learn/courses/30/lessons/17677)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
- 비교할 문자열에 대해 2개의 알파벳만으로 이루어진 문자열 다중집합을 각각 구하고 두 다중집합의 교집합과 합집합을 구해 자카드 유사도를 구하는 문제.
- 둘 다 공집합일 경우 나눗셈이 불가능하므로 자카드 유사도는 1로 한다.
- 알파벳은 대소문자를 같게 취급한다.
- 자카드 유사도에 65536을 곱해서 리턴한다.


<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
집합 + 구현
<br>

**어떤 방식으로 풀이할건가요?**
- 주어진 문자열을 모두 대문자로 만든 다음, 숫자, 공백, 특수문자가 포함되지 않은 문자열 다중집합을 만든다.
- 이때, 만든 다중집합이 둘 다 공집합이면 1 * 65536 리턴
- 교집합은 intersection 리스트와 temp 리스트를 만들어서 다중집합 하나를 넣어놓고, 다른 다중집합의 문자열을 반복문으로 돌면서 temp 리스트에 포함되어 있으면 교집합 리스트에 추가하고 temp 리스트에서는 제거하는 방식으로 교집합을 구한다.
- 합집합은 A + B - (A ∩ B) 식을 활용해서 addAll 메소드로 A + B를 구하고 앞서 구한 intersection 리스트에 포함된 원소를 제거하는 방식으로 구한다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
시간복잡도: 다중집합을 만드는데 O(n), 교집합과 합집합을 만드는데 O(n*m)이므로 최종 O(n*m)
공간복잡도: 다중집합을 만드는데 필요한 O(n), 교집합과 합집합을 만드는데 O(n+m)이므로 최종 O(n+m)



<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->
쉽게 풀려고 retainAll 썼다가 반례를 발견해버려서 교집합 로직을 다시 짰다. 요령 피우지 않겠습니다...



<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 56분
<img width="806" alt="11/14 프로그래머스 17677" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/5c46ded9-e57b-411a-8709-dc0065b9e88a">



<br/>
