### PR TITLE
[공통 - Minseon] 150368

### DIFF
--- a/programmers/150368/Minseon_150368.java
+++ b/programmers/150368/Minseon_150368.java
@@ -1,0 +1,74 @@
+/**
+ * == 150368. 이모티콘 할인행사 ==
+ * 입력 : 카카오톡 사용자 n명의 구매 기준 배열 users, 이모티콘 m개의 정가 배열 emoticons
+ * 출력 : 행사 목적을 최대한으로 달성했을 때의 이모티콘 플러스 서비스 가입 수, 이모티콘 매출액
+ */
+
+import java.util.*;
+
+class Solution {
+    int maxMembers = 0; // 최대 서비스 가입자
+    int maxRevenue = 0; // 최대 판매액
+
+    public int[] solution(int[][] users, int[] emoticons) {
+        /* 할인 비율 범위 구하기 */
+        int minDiscount = 40;
+        for (int[] user : users) {
+            minDiscount = Math.min(minDiscount, user[0]);
+        }
+        minDiscount = ceilTens(minDiscount);    // 10 20 30 40 올림 연산
+
+        /* 이모티콘 할인행사 결과 */
+        makePermutation(minDiscount, emoticons.length, new ArrayList<>(), users, emoticons);
+        int[] answer = {maxMembers, maxRevenue};
+        return answer;
+    }
+
+    public void makePermutation(int minDiscount, int maxDepth, List<Integer> discount, int[][] users, int[] emoticons) {
+        if (discount.size() == maxDepth) {
+            getCosts(users, emoticons, discount);   // 판매액 & 서비스 가입자 구하기
+            return;
+        }
+
+        for (int i = minDiscount; i <= 40; i += 10) {
+            discount.add(i);
+            makePermutation(minDiscount, maxDepth, discount, users, emoticons);
+            discount.remove(discount.size() - 1);
+        }
+    }
+
+    /* 판매액 및 서비스 가입자 계산 */
+    public void getCosts(int[][] users, int[] emoticons, List<Integer> discount) {
+        int members = 0; int revenue = 0;
+        for (int[] user : users) {
+            int costs = 0;
+            for (int i = 0; i < emoticons.length; i++) {
+                double purchase = (double) (100 - discount.get(i)) / 100;
+                if (discount.get(i) >= user[0]) costs += emoticons[i] * purchase;
+                if (costs >= user[1]) {
+                    members++;
+                    costs = 0;
+                    break;
+                }
+            }
+            revenue += costs;
+        }
+
+        // 목표
+        if (members > maxMembers) {
+            maxMembers = members;
+            maxRevenue = revenue;
+        } else if (members == maxMembers) {
+            maxRevenue = Math.max(maxRevenue, revenue);
+        }
+    }
+
+    /* 10단위 올림 */
+    public int ceilTens(int number) {
+        if (number % 10 == 0) {
+            return number;
+        } else {
+            return number + (10 - number % 10);
+        }
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 150368번](https://school.programmers.co.kr/learn/courses/30/lessons/150368)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
다음과 같은 목표를 최대한으로 이루는 서비스 가입자 수와 판매액을 구하는 문제.
```
1. 이모티콘 플러스 서비스 가입자를 최대한 늘리는 것.
2. 이모티콘 판매액을 최대한 늘리는 것.
```
- 이모티콘의 할인율을 10%, 20%, 30%, 또는 40%
- 사용자의 기준 비율 이상 할인하는 이모티콘을 모두 구매한다.
- 이모티콘 구매 비용의 합이 기준 가격 이상이 된다면, 이모티콘 구매를 모두 취소하고 이모티콘 플러스 서비스에 가입한다.



<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
백트래킹을 이용한 완전탐색
<br>

**어떤 방식으로 풀이할건가요?**
- 이모티콘의 최대 개수가 7개이고, 할인 비율도 10단위이기 때문에 최악의 경우에도 경우의 수가 4^7개가 된다. -> 완전탐색하기 좋다.
- 할인율이 기준 비율 이하면 구매하지 않으므로 최소 할인율을 구하고 10 단위로 올림 연산을 해준다.
- 백트래킹을 이용해 순열을 만들고 순열의 길이가 이모티콘의 개수와 같아지면 사용자별 구매액을 구한다.
  - 기준 비율 이상의 할인율을 반영한 금액을 구매액에 더한다.
  - 구매액이 기준 비용 이상이 되면 구매액을 0으로 바꾸고 이모티콘 서비스에 가입한다.
- 모든 할인율 경우의 수를 순회하며 모든 사용자에 대해 목표를 최대한 달성하는 조건을 구한다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
할인 비율 범위의 길이를 n, users의 길이를 u, emoticons의 길이를 e라고 하면 O(n^e*u*e)




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->
문제를 제대로 안 봐서 기준 비용과 같은 경우에도 서비스 가입을 한다는 조건을 못 보고 초과로 구현했음.



<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 1시간
<img width="778" alt="12/05 프로그래머스 150368(1)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/6dfc281e-475e-40ad-a772-a35e056dd605">
<img width="777" alt="12/05 프로그래머스 150368(2)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/eef461b1-7ad8-43dd-82fc-01b2576aed02">



<br/>
