### PR TITLE
[개별 - Minseon] 86971

### DIFF
--- a/programmers/86971/Minseon_86971.java
+++ b/programmers/86971/Minseon_86971.java
@@ -1,0 +1,59 @@
+/**
+ * == 86971. 전력망을 둘로 나누기 ==
+ * 입력 : 송전탑의 개수 n, 전선 정보 wires
+ * 출력 : 전선 하나를 끊었을 때 두 전력망이 가지고 있는 송전탑 개수의 차이의 최솟값
+ */
+
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] wires) {
+        int answer = 100;
+
+        for (int i = 0; i < wires.length; i++) {
+            List<List<Integer>> graph = initGraph(n);
+            boolean[] visited = new boolean[n+1];
+            int towers1 = 0; int towers2 = 0;
+
+            makeGraph(graph, wires, i);
+            towers1 = getTowers(wires[i][0], 0, visited, graph);
+            towers2 = getTowers(wires[i][1], 0, visited, graph);
+
+            int diff = Math.abs(towers1 - towers2);
+            answer = diff < answer ? diff : answer;
+        }
+
+        return answer;
+    }
+
+    /* 전력망이 가지고 있는 송전탑의 개수 */
+    public int getTowers(int v, int towers, boolean[] visited, List<List<Integer>> graph) {
+        visited[v] = true; towers++;
+
+        for (int w : graph.get(v)) {
+            if (visited[w]) continue;
+            else towers = getTowers(w, towers, visited, graph);
+        }
+
+        return towers;
+    }
+
+    /* 그래프 초기화 */
+    public List<List<Integer>> initGraph(int n) {
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        return graph;
+    }
+
+    /* 끊은 전선을 제외한 전력망 */
+    public void makeGraph(List<List<Integer>> graph, int[][] wires, int w) {
+        for (int i = 0; i < wires.length; i++) {
+            if (i == w) continue;
+            graph.get(wires[i][0]).add(wires[i][1]);
+            graph.get(wires[i][1]).add(wires[i][0]);
+        }
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 86971번](https://school.programmers.co.kr/learn/courses/30/lessons/86971)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
하나의 트리로 이어진 그래프를 둘로 나눴을 때 노드 개수의 차이를 최소화하는 문제.
=> n이 최대 100이므로 전선의 개수는 최대 99개가 되기 때문에 완전탐색으로 풀 수 있다



<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
완전탐색, dfs
<br>

**어떤 방식으로 풀이할건가요?**
- 전선을 돌아가면서 하나씩 제외하면서 그래프를 생성한다.
- 제외한 전선을 구성하는 송전탑은 반드시 다른 전력망에 속하므로 두 송전탑을 시작 노드로 잡는다.
- dfs를 이용해서 두 전력망에 포함된 송전탑의 개수를 각각 구한다.
- 송전탑 개수의 차이의 절댓값을 구했을 때 가장 작은 값으로 업데이트
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
간선의 개수가 최대 99, n이 최대 100이므로 dfs를 이용해도 시간적으로 무리는 없다. 최악의 경우 O(n^2)




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->




<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 23분
<img width="787" alt="12/19 프로그래머스 86971" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/e90debc5-45f2-400f-bc33-6db2ff8ad37c">



<br/>
