### PR TITLE
[공통 - Yebin] 42890

### DIFF
--- a/programmers/42890/Yebin_42890.java
+++ b/programmers/42890/Yebin_42890.java
@@ -1,0 +1,56 @@
+import java.util.*;
+
+class Solution {
+    int rCount; // 튜플 개수
+    int cCount; // 속성 개수
+    List<List<Integer>> candidateKeys;
+    
+    public int solution(String[][] relation) {
+        rCount = relation.length;    
+        cCount = relation[0].length; 
+        candidateKeys = new ArrayList<>();
+        
+        for (int i = 1; i <= cCount; i++) {
+            List<Integer> temp = new ArrayList<>();
+            generateCandidateKeys(0, i, temp, relation);
+        }
+        
+        return candidateKeys.size();
+    }
+    
+    private void generateCandidateKeys(int temp, int count
+                                      , List<Integer> currentKey
+                                      , String[][] relation) {
+        if (count == 0) {   // 부분 집합 생성 완료
+            if (isUnique(currentKey, relation) && isMinimal(currentKey)) {
+                candidateKeys.add(new ArrayList<>(currentKey));
+            }
+            return;
+        }
+        for (int i = temp; i < cCount; i++) {   // 부분 집합 생성 재귀
+            currentKey.add(i);
+            generateCandidateKeys(i + 1, count - 1, currentKey, relation);
+            currentKey.remove(currentKey.size() - 1);
+        }
+    }
+    
+    private boolean isUnique(List<Integer> currentKey, String[][] relation) {
+        Set<String> tuple = new HashSet<>();
+        for (int i = 0; i < rCount; i++) {
+            StringBuilder sb = new StringBuilder();
+            for (int key : currentKey) {
+                sb.append(relation[i][key]);
+            }
+            tuple.add(sb.toString());
+        }
+        
+        return tuple.size() == rCount;  // 중복된 정보가 없을 때 true
+    }
+    
+    private boolean isMinimal(List<Integer> currentKey) {
+        for (List<Integer> validKey : candidateKeys) {
+            if (currentKey.containsAll(validKey)) return false;   
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[42890번 후보키](https://school.programmers.co.kr/learn/courses/30/lessons/42890)**



<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->

- 후보키의 후보는 멱집합이다
- 후보키는 다음 조건을 만족한다
  - 유일성 
    - 튜플을 유일하게 식별함
    - 키를 만들었을 때 겹치는게 있으면 안됨
  - 최소성 
    - 속성을 하나라도 제거했을 때 유일성이 깨짐
    - 속성을 제거했는데 후보키가 되는 경우가 있으면 안됨

<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
- dfs(멱집합 만들 때)
- 구현

<br>

**어떤 방식으로 풀이할건가요?**
- 원소를 1개 ~ 속성 개수 만큼 가지는 부분집합 생성
- 유일성 확인
  - 속성을 조합하여 키를 만들고 Set을 이용해 튜플 개수만큼 나오는지 확인
- 최소성 확인
  - 기존의 후보키가 이 키의 부분 집합이 되는지 확인
    - 집합의 원소를 1부터 늘려가기 때문에 속성을 하나 이상 제거한 것으로 볼 수 있음
- 최종 후보키 리스트의 크기를 반환

<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
- 시간복잡도 : 부분집합 만드는데 O(n^2)지만 속성이 최대 8개라 괜찮음
- 공간복잡도 : 재귀 깊이 최대 8이고 O(n). 공간복잡도 면에서 어디까지가 안전한 숫자인지는 아직 모르겠음.




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->
- 최소성을 확인하기 위해 하나 이상 제거한 집합을 다시 만들려고 했던 점
  - 원소 개수가 작은 것부터 부분집합을 만들어서 후보키를 확정지어가는 사고의 전환이 필요했음



<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
54분
<img width="860" alt="스크린샷 2024-01-08 오전 6 46 15" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/eb488df2-299b-4d50-9157-b1a6c420be4b">
<img width="862" alt="스크린샷 2024-01-08 오전 6 46 26" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/c405db0e-7bb1-470a-9a2d-f71fb0d4998f">


<br/>
