### PR TITLE
[개별 - Yebin] 68936

### DIFF
--- a/programmers/68936/Yebin_68936.java
+++ b/programmers/68936/Yebin_68936.java
@@ -1,0 +1,36 @@
+import java.util.*;
+
+class Solution {
+    int[] answer;
+    public int[] solution(int[][] arr) {
+        answer = new int[2]; // [0의 개수, 1의 개수]
+        int n = arr.length;
+        compression(arr, 0, 0, n);
+        return answer;
+    }
+    
+    private void compression(int[][] arr, int r, int c, int size) {
+        boolean canCompress = true;
+        int quad = arr[r][c];
+        for (int x = r; x < r + size; x++) {
+            for (int y = c; y < c + size; y++) {
+                if (arr[x][y] != quad) {
+                    canCompress = false;
+                    break;
+                }
+            }
+            if (!canCompress) break;
+        }
+        
+        if (canCompress) {
+            answer[quad]++;
+            return;
+        }
+        
+        int newSize = size / 2;
+        compression(arr, r, c, newSize);
+        compression(arr, r, c + newSize, newSize);
+        compression(arr, r + newSize, c, newSize);
+        compression(arr, r + newSize, c + newSize, newSize);
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[68936번 쿼드압축 후 개수 세기](https://school.programmers.co.kr/learn/courses/30/lessons/68936)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->

- 압축 재귀함수는 다음 동작을 포함함
  - 특정 영역 S의 모든 수가 같은 값인지 확인
  - 모두 같은 수이면 해당 수 카운트를 🆙 
  - 아니면 정확히 4등분 하여 압축 재귀함수를 수행 
  - 압축 재귀함수는 최악의 경우 한 칸인 영역이 되어서야 카운트 되고 끝이 남



<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
- 재귀
<br>

**어떤 방식으로 풀이할건가요?**
- 압축 재귀 함수 실행 
  - 압축이 가능하면 해당 수를 카운트하고 
  - 불가능하면 사등분 해서 다시 압축 재귀 함수를 실행
    - 사등분하면 크기는 /2되고 시작점이 (x,y)와 새로운 크기만큼 차이나는 시작점을 갖게 됨 
    ``` 
    (x, y)
    (x + size, y)
    (x, y + size)
    (x + size, y + size)
    ```
- 0과 1 카운트 결과 반환
  - 편하게 필드로 선언함
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**

- 시간복잡도 : 영역 내 모두 같은 수인지 확인하는게 2중 반복문이지만 영역이 기하급수적으로 작아짐. O(log n)
- 공간복잡도 : 영역의 최대 크기가 1024=2^10 이므로 재귀 최대 깊이 10. 최종적으로 남는 0과 1을 세는 배열 하나 있으므로 O(1).



<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->

- 인자로 영역의 시작점과 끝점을 보내려다 연산 실패 
  - 헷갈리게 점을 일일이 지정해줄 필요 없고 시작점에 크기만 있으면 끝점을 고민하지 않아도 되는걸 


<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->

20분

<img width="861" alt="스크린샷 2024-01-08 오후 7 01 42" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/17877c2f-5fb3-434a-b93c-5f7728e98fdb">


<br/>