### PR TITLE
[공통 - Yebin] 250136

### DIFF
--- a/programmers/250136/Yebin_250136.java
+++ b/programmers/250136/Yebin_250136.java
@@ -8,53 +8,67 @@ class Solution {
     private Map<Integer, Integer> oilReserves;
     private int n;
     private int m;
-    
+
     public int solution(int[][] land) {
         int answer = 0;
         n = land.length;
         m = land[0].length;
-        
+
         oilList = new ArrayList<>();
         for (int j = 0; j < m; j++) oilList.add(new HashSet<>());
         oilReserves = new HashMap<>();
-        
+
         int oilId = -1;
-        for (int i = 0; i < n; i++) {
-            for (int j = 0; j < m; j++) {
-                if (land[i][j] == 1) dfs(land, i, j, oilId--);
+        for (int j = 0; j < m; j++) {
+            for (int i = 0; i < n; i++) {
+                if (land[i][j] == 1) {
+                    dfs(land, i, j, oilId);
+                    oilId--;
+                }
             }
         }
-        
+
         return calculateMaxOil();
     }
-    
-    private void dfs(int[][] land, int x, int y, int oilId) {
-        land[x][y] = oilId;
-        oilList.get(y).add(oilId);
-        oilReserves.put(oilId, oilReserves.getOrDefault(oilId, 0) + 1);
-        
-        for (int i = 0; i < 4; i++) {
-            int nx = x + diff[i][0];
-            int ny = y + diff[i][1];
-            
-            if (nx < 0 || nx > n-1 || ny < 0 || ny > m-1 
-               || land[nx][ny] == 0 || land[nx][ny] != 1) continue;
-            
-            dfs(land, nx, ny, oilId);
+
+    private void dfs(int[][] land, int startX, int startY, int oilId) {
+        Stack<int[]> stack = new Stack<>();
+        stack.push(new int[]{startX, startY});
+
+        while (!stack.isEmpty()) {
+            int[] current = stack.pop();
+            int x = current[0];
+            int y = current[1];
+
+            if (land[x][y] != 1) continue;
+
+            land[x][y] = oilId;
+            oilList.get(y).add(oilId);
+            oilReserves.put(oilId, oilReserves.getOrDefault(oilId, 0) + 1);
+
+            for (int i = 0; i < 4; i++) {
+                int nx = x + diff[i][0];
+                int ny = y + diff[i][1];
+
+                if (nx >= 0 && nx < n && ny >= 0 && ny < m && land[nx][ny] == 1) {
+                    stack.push(new int[]{nx, ny});
+                }
+            }
         }
     }
-    
+
     private int calculateMaxOil() {
         int answer = 0;
         for (Set<Integer> col : oilList) {
-            if (col.isEmpty()) continue;
-            
-            int temp = 0;
-            for (int oilId : col) temp += oilReserves.get(oilId);
-            
-            answer = Math.max(temp, answer);
+            if (!col.isEmpty()) {
+                int temp = 0;
+                for (int oilId : col) {
+                    temp += oilReserves.get(oilId);
+                }
+                answer = Math.max(temp, answer);
+            }
         }
-        
+
         return answer;
     }
 }

--- a/programmers/250136/Yebin_250136.java
+++ b/programmers/250136/Yebin_250136.java
@@ -1,0 +1,60 @@
+// https://school.programmers.co.kr/learn/courses/30/lessons/250136
+// [PCCP 기출문제] 2번 / 석유 시추
+import java.util.*;
+
+class Solution {
+    private int[][] diff = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+    private List<Set<Integer>> oilList;
+    private Map<Integer, Integer> oilReserves;
+    private int n;
+    private int m;
+    
+    public int solution(int[][] land) {
+        int answer = 0;
+        n = land.length;
+        m = land[0].length;
+        
+        oilList = new ArrayList<>();
+        for (int j = 0; j < m; j++) oilList.add(new HashSet<>());
+        oilReserves = new HashMap<>();
+        
+        int oilId = -1;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < m; j++) {
+                if (land[i][j] == 1) dfs(land, i, j, oilId--);
+            }
+        }
+        
+        return calculateMaxOil();
+    }
+    
+    private void dfs(int[][] land, int x, int y, int oilId) {
+        land[x][y] = oilId;
+        oilList.get(y).add(oilId);
+        oilReserves.put(oilId, oilReserves.getOrDefault(oilId, 0) + 1);
+        
+        for (int i = 0; i < 4; i++) {
+            int nx = x + diff[i][0];
+            int ny = y + diff[i][1];
+            
+            if (nx < 0 || nx > n-1 || ny < 0 || ny > m-1 
+               || land[nx][ny] == 0 || land[nx][ny] != 1) continue;
+            
+            dfs(land, nx, ny, oilId);
+        }
+    }
+    
+    private int calculateMaxOil() {
+        int answer = 0;
+        for (Set<Integer> col : oilList) {
+            if (col.isEmpty()) continue;
+            
+            int temp = 0;
+            for (int oilId : col) temp += oilReserves.get(oilId);
+            
+            answer = Math.max(temp, answer);
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[250136번 [PCCP 기출문제] 2번 / 석유 시추](https://school.programmers.co.kr/learn/courses/30/lessons/250136)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->

- 어떤 열에 걸쳐 있는 석유 덩어리들의 크기의 합을 구하는 문제
- 석유 덩어리의 크기는 상하좌우로 붙어 있는 칸의 개수와 같다
- bfs || dfs 로 석유 덩어리의 크기를 구한다
- 열마다 Set 을 만들고 걸쳐있는 석유 덩어리의 고유 번호를 저장한다
- 걸쳐있는 모든 석유 덩어리의 크기를 더하여 가장 큰 합을 구한다



<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
- 완전탐색 (dfs || bfs)
<br>

**어떤 방식으로 풀이할건가요?**
- 열에 걸쳐있는 석유 덩어리 정보를 저장할 List<Set<Integer>>
- 석유 덩어리의 고유 번호와 크기를 저장할 Map<Integer, Integer>>
- dfs로 덩어리의 크기를 구함
  - 해당 덩어리의 고유 번호를 열의 Set에 저장
- 열에 걸쳐있는 덩어리들의 크기의 합을 구하여 비교
- 가장 큰 합을 반환!

<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
- 시간복잡도 : 완전탐색을 위한 이중반복문이 있으므로 O(n^2)
- 공간복잡도 : 스택 메모리 생각 못함. 열에 걸쳐있는 덩어리 저장하는게 O(n).




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->

- 재귀의 스택오버플로우를 고려하지 않은 점
  - 모든 점이 이어져 있다면 500x500 이니까 깊이가 500 까지도 갈 수 있다


<br>
<br>



### 5️⃣ 인증

1시간
 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->

재귀 dfs
<img width="1502" alt="스크린샷 2024-01-12 오후 11 57 35" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/a92c3a4f-ac3c-4f3d-b3ad-ebe80fa68401">

Stack + 반복문 dfs
<img width="1486" alt="스크린샷 2024-01-13 오전 12 38 45" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/69137469/7283731b-73ce-4c08-9a74-4f91d7104f85">


<br/>
