### PR TITLE
[공통 - Minseon] 181188

### DIFF
--- a/programmers/181188/Minseon_181188.java
+++ b/programmers/181188/Minseon_181188.java
@@ -1,0 +1,34 @@
+/**
+ * == 181188. 요격 시스템 ==
+ * 입력 : 폭격 미사일의 x좌표 범위 목록 targets
+ * 출력 : 모든 폭격 미사일을 요격하기 위해 필요한 요격 미사일의 최소 개수
+ */
+
+import java.util.PriorityQueue;
+import java.util.Comparator;
+
+class Solution {
+    public int solution(int[][] targets) {
+        /* 폭격 미사일 좌표 끝구간 기준으로 정렬 */
+        PriorityQueue<int[]> heapq = new PriorityQueue<>(Comparator.comparingInt(arr -> arr[1]));
+
+        for (int[] target : targets) {
+            heapq.add(target);
+        }
+
+        /* 요격 미사일 발사 */
+        int missiles = 0;               // 요격 미사일 개수
+        double location = 0.0;          // 요격 위치
+
+        while (!heapq.isEmpty()) {
+            int[] target = heapq.poll();
+            if (target[0] < location) continue;     // 요격 가능한 위치
+            else {              // 요격 불가능한 경우 -> 새로운 요격 미사일 발사
+                location = target[1] - 0.5;
+                missiles++;
+            }
+        }
+
+        return missiles;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 181188번](https://school.programmers.co.kr/learn/courses/30/lessons/181188)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
폭격 미사일이 (s, e) 구간으로 발사될 때 y축에 평행하게 움직이는 요격 미사일로 모든 폭격 미사일을 요격할 수 있는 최소 개수를 구하는 문제.
- x == s, x == e 일 때는 요격할 수 없으며, s와 e사이의 실수 좌표에서는 요격할 수 있다.




<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
우선순위 큐를 이용한 그리디
<br>

**어떤 방식으로 풀이할건가요?**
예전에 풀었던 단속카메라(#129) 문제와 비슷하다.
- e를 기준으로 오름차순 정렬한다. 문제의 테스트케이스를 예시로 들면 `[1,4], [4,5], [3,7], [4,8], [5,12], [11,13], [10,14]`가 된다.
- 요격 발사 위치는 poll한 타깃의 e - 0.5로 한다. 예시에서는 4 - 0.5인 3.5가 된다.
- 다음 poll한 타깃의 s가 요격 위치보다 작으면 같이 요격할 수 있는 타깃이 된다. 하지만 예시에서는 [4,5]는 3.5로 요격할 수 없다.
  - 이런 경우 새로운 타깃의 e - 0.5의 위치에도 요격 미사일을 쏜다. 예시에서는 5 - 0.5인 4.5가 되고 뒤에 차례로 오는 [3,7], [4,8] 폭격 미사일을 요격할 수 있다.
- 이런 식으로 타깃을 모두 처리할 때까지 앞의 과정을 계속 반복한다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
O(NlogN)




<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->




<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간: 21분
<img width="663" alt="1/31 프로그래머스 181188" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/c614aad6-c499-480f-95eb-adc1166b3bc8">



<br/>
