### PR TITLE
[공통 - Minseon] 72412

### DIFF
--- a/programmers/72412/Minseon_72412.java
+++ b/programmers/72412/Minseon_72412.java
@@ -1,0 +1,78 @@
+/**
+ * == 72412. 순위 검색 ==
+ * 입력 : 지원자의 정보와 코딩테스트 점수 문자열 배열 info, 문의조건 문자열 배열 query
+ * 출력 : 각 문의조건에 해당하는 사람들의 숫자 배열
+ */
+
+import java.util.*;
+
+class Solution {
+    Map<String, List<Integer>> infoMap = new HashMap<>();
+    int score;
+
+    public int[] solution(String[] info, String[] query) {
+        /* 지원자 정보 해시맵 */
+        for (String applicant : info) {
+            String[] splitedInfo = applicant.split(" ");
+            score = Integer.parseInt(splitedInfo[4]);
+            dfs(0, splitedInfo, new String[4]);
+        }
+
+        /* 지원자 코딩테스트 점수 내림차순 정렬 */
+        for (String key : infoMap.keySet()) {
+            Collections.sort(infoMap.get(key), Collections.reverseOrder());
+        }
+
+        /* 쿼리 */
+        int[] answer = new int[query.length];
+        for (int i = 0; i < query.length; i++) {
+            String[] splitedQuery = query[i].split(" ");
+            int score = Integer.parseInt(splitedQuery[7]);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append(splitedQuery[0]);
+            for (int j = 1; j < 7; j++) {
+                if (!splitedQuery[j].equals("and")) {
+                    sb.append(" ");
+                    sb.append(splitedQuery[j]);
+                }
+            }
+            String key = sb.toString();
+
+            if (infoMap.containsKey(key)) {
+                List<Integer> scores = infoMap.get(key);
+                answer[i] = binarySearch(score, scores);
+            }
+        }
+
+        return answer;
+    }
+
+    /* dfs */
+    public void dfs(int depth, String[] splitedInfo, String[] sb) {
+        if (depth == 4) {
+            String condition = String.join(" ", sb);
+            if (!infoMap.containsKey(condition)) infoMap.put(condition, new ArrayList<>());
+            infoMap.get(condition).add(score);
+        } else {
+            sb[depth] = splitedInfo[depth];
+            dfs(depth+1, splitedInfo, sb);
+            sb[depth] = "-";    // 각 정보를 포함하지 않은 경우도 고려
+            dfs(depth+1, splitedInfo, sb);
+        }
+    }
+
+    /* 이진 탐색 */
+    public int binarySearch(int score, List<Integer> list) {
+        int left = 0; int right = list.size() - 1;
+
+        while (left <= right) {
+            int mid = (left + right) / 2;
+
+            if (list.get(mid) < score) right = mid - 1;
+            else left = mid + 1;
+        }
+
+        return left;
+    }
+}


### PR DESCRIPTION
<!-- pr 이름은 [ 공통 or 개별 - 본인이름] 문제번호 ex. '[공통 - Suhwa] 문제번호' or '[개별 - Suhwa] 문제번호' 로 통일해주세요. 
라벨로 알고리즘 카테고리(여러개 가능), 알고리즘 난이도, 해당 주의 시작날짜, 본인이름을 표시해 주세요.  -->

### 1️⃣ 어떤 문제인가요?



<!-- 문제 번호에 하이퍼링크로 문제사이트의 문제페이지를 첨부해주세요. -->
**[프로그래머스 72412번](https://school.programmers.co.kr/learn/courses/30/lessons/72412)**






<br>
<br>



### 2️⃣ 어떻게 문제를 분석했나요?


 <!-- 본인 방식으로 문제를 분석한 내용을 간략하게 적어주세요. 
 문제 예제에 대입해도, 그냥 간단하게 문제를 요약해도 좋습니다. -->
문자열 형태로 지원자들의 4가지 조건과 코딩테스트 점수가 주어질 때, 주어진 쿼리에 해당하는 지원자들의 수를 구하는 문제.
- 이때 쿼리는 '-'을 이용해 해당 조건을 고려하지 않을 수 있다.



<br>
<br>





### 3️⃣ 어떻게 문제를 풀었나요?



<!-- 아래의 항목들을 자유롭게 포함하여 풀이를 써주세요  -->

**문제는 어떤 유형인가요?**
해시, 이진탐색, dfs
<br>

**어떤 방식으로 풀이할건가요?**
- 지원자들의 정보를 저장하기 위해 해시맵을 이용한다.
  - 이때, 해시맵은 4가지 조건 문자열을 key로 하고, 해당 key에 해당하는 점수 리스트를 value로 한다.
  - 지원자들의 정보가 들어오면 각 조건이 포함되지 않는 경우('-')의 key를 dfs를 이용해서 만든다.
  - dfs로 만든 키에 해당 지원자의 코딩테스트 점수를 넣어준다.
- 해시맵에 저장된 모든 점수 리스트를 내림차순 정렬한다. -> 이후 이진탐색을 위함
- 쿼리 배열을 순회하면서 StringBuilder를 이용해 and와 기준 점수를 제거한 쿼리를 만든다.
  - 해당 쿼리를 해시맵에서 검색해서 점수 리스트를 불러온다.
  - 점수 리스트를 이진 탐색하여 기준 점수보다 낮은 첫번째 점수의 위치를 찾는다. -> 그 위치가 조건에 해당하는 지원자의 수가 된다.
<br>

**시간복잡도 공간복잡도를 어떻게 고려했나요?**
dfs는 O(2^4N), 해시맵 정렬에서 O(NlogN), 이진탐색에서 O(M*logN) 여기서 N은 점수 리스트의 길이, M은 쿼리 개수
-> O(NlogN)



<br>
<br>



### 4️⃣ 아쉬웠던 점


 <!-- 문제를 풀면서 겪은 시행착오로 인한 아쉬웠던 점을 써주세요. 없다면 쓰지 않아도 좋습니다. -->
계속 효율성에서 통과가 안 됐는데 이진탐색을 쓸 생각을 못했던 것 같다.



<br>
<br>



### 5️⃣ 인증

 <!-- 문제를 풀고 통과한 사진을 캡쳐하여 넣어주세요. -->
소요 시간 : 1시간 13분
<img width="668" alt="2/2 프로그래머스 72412(1)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/315aa1a0-ce1b-45ac-8a52-4b6bd6a53d0d">
<img width="669" alt="2/2 프로그래머스 72412(2)" src="https://github.com/Algorithm-SQL-Study/Algorithm-SQL-Study/assets/76639061/672a948a-6e69-467d-8c3a-1da7588dd426">



<br/>
